### PR TITLE
Test showing that temps escape their scope

### DIFF
--- a/PicoCore/PicoInterpreterTest.class.st
+++ b/PicoCore/PicoInterpreterTest.class.st
@@ -321,6 +321,14 @@ PicoInterpreterTest >> testSwappingArgArg2 [
 	
 ]
 
+{ #category : #'interpreter tests' }
+PicoInterpreterTest >> testTempsShouldNotEscapeMethods [
+
+	| inst |
+	inst := pointClass allocateAnInstance.
+	self assert: (inst send: #methodWithTemp) isNil
+]
+
 { #category : #'primitive message tests' }
 PicoInterpreterTest >> testUsingTempValue [
 	|  inst val |

--- a/PicoCore/PicoPointCode.class.st
+++ b/PicoCore/PicoPointCode.class.st
@@ -72,6 +72,22 @@ PicoPointCode >> messageSendToGlobal [
 	^ PicoBlop giveClassNamed: #PicoPoint ifAbsent: [nil].
 ]
 
+{ #category : #messages }
+PicoPointCode >> methodAccessingTemp [
+
+	| temp |
+	^ temp
+]
+
+{ #category : #messages }
+PicoPointCode >> methodWithTemp [
+
+	| temp |
+	
+	temp := 7.
+	^ self send: #methodAccessingTemp
+]
+
 { #category : #'for lookup tests' }
 PicoPointCode >> notOverridenFoo [ 
 	


### PR DESCRIPTION
It seems we can access the temps of one method from another one ;)